### PR TITLE
feat(routes): add prerender params for detail route

### DIFF
--- a/Note.txt
+++ b/Note.txt
@@ -75,3 +75,5 @@ npm install @netlify/angular-runtime
     "build": "ng build --configuration production"
   }
 }
+
+- Buil test trước khi deploy : npm run build

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -2,6 +2,17 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
   {
+    path: 'detail/:id',
+    renderMode: RenderMode.Prerender,
+    getPrerenderParams: async () => {
+      return [
+        { id: '1' },
+        { id: '2' },
+        { id: '3' }
+      ];
+    }
+  },
+  {
     path: '**',
     renderMode: RenderMode.Prerender
   }


### PR DESCRIPTION
Add prerender parameters for the detail route to support dynamic rendering of pages with IDs 1, 2, and 3. This ensures that these pages are pre-rendered during the build process, improving performance and SEO.