### PR TITLE
ci: increase Node.js memory limit for build process

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
   command = "npm run build"
   publish = "dist/learn-angular-01/browser"
+  environment = { NODE_OPTIONS = "--max_old_space_size=4096" }
 
 [[redirects]]
   from = "/*"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --configuration production",
+    "build": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:learn-angular-01": "node dist/learn-angular-01/server/server.mjs"


### PR DESCRIPTION
This change updates the Netlify configuration and package.json to increase the Node.js memory limit to 4096 MB. This ensures the build process does not fail due to insufficient memory allocation.