### PR TITLE
ci: increase memory limits and adjust build configurations

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -48,21 +48,15 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "8kb",
+                  "maximumError": "16kb"
                 }
-              ],
-              "outputHashing": "all"
-            },
-            "development": {
-              "optimization": false,
-              "extractLicenses": false,
-              "sourceMap": true
+              ]
             }
           },
           "defaultConfiguration": "production"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   command = "npm run build"
   publish = "dist/learn-angular-01/browser"
-  environment = { NODE_OPTIONS = "--max_old_space_size=4096" }
+  environment = { NODE_OPTIONS = "--max_old_space_size=10000" }
 
 [[redirects]]
   from = "/*"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng build --configuration production",
+    "build": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng build --configuration production --optimization=false",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:learn-angular-01": "node dist/learn-angular-01/server/server.mjs"


### PR DESCRIPTION
Increase the `max_old_space_size` in Netlify and package.json to handle larger builds. Adjust Angular build budgets and remove unnecessary configurations to optimize the build process.